### PR TITLE
Request Bootstrap glyph fonts at expected path

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -50,7 +50,7 @@ gulp.task('html', ['inject', 'partials'], function () {
     .pipe(jsFilter.restore)
     .pipe(cssFilter)
     .pipe($.sourcemaps.init())
-    .pipe($.replace('../../bower_components/bootstrap-sass/assets/fonts/bootstrap/', '../fonts/'))
+    .pipe($.replace('../bower_components/bootstrap-sass/assets/fonts/bootstrap/', '../fonts/bootstrap/'))
     .pipe($.minifyCss({ processImport: false }))
     .pipe($.sourcemaps.write('maps'))
     .pipe(cssFilter.restore)

--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -2,7 +2,7 @@
  *  If you want to override some bootstrap variables, you have to change values here.
  *  The list of variables are listed here bower_components/bootstrap-sass/assets/stylesheets/bootstrap/_variables.scss
  */
-$icon-font-path: "bower_components/bootstrap-sass/assets/fonts/bootstrap/";
+$icon-font-path: "../bower_components/bootstrap-sass/assets/fonts/bootstrap/";
 @import "bower_components/bootswatch/cerulean/_variables.scss";
 @import "bower_components/bootstrap-sass/assets/stylesheets/_bootstrap.scss";
 @import "bower_components/bootswatch/cerulean/_bootswatch.scss";


### PR DESCRIPTION
Adjusts $icon-font-path in src/app/index.scss and makes corresponding adjustment in the Gulp gulp/build.js file