### PR TITLE
Match ng app name in build script to src module name

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -19,7 +19,7 @@ gulp.task('partials', function () {
       quotes: true
     }))
     .pipe($.angularTemplatecache('templateCacheHtml.js', {
-      module: 'formioAppTemplate',
+      module: 'formioApp',
       root: 'app'
     }))
     .pipe(gulp.dest(conf.paths.tmp + '/partials/'));


### PR DESCRIPTION
Build script was using `formioAppTemplate` instead of `formioApp` like the scripts in /src